### PR TITLE
Small fixes for Camera Position plug-in

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,6 @@
     "author": "Diego Prado Gesto",
     "version": "0.0.1",
     "description": "Enter the position of the camera and it will rotate and position in this place. Very useful if you want to take screenshots always from the same perspective.",
-    "supported_sdk_versions": ["6.1.0"],
+    "supported_sdk_versions": ["7.0.0"],
     "i18n-catalog": "cura"
 }

--- a/resources/qml/CameraPositionPanel.qml
+++ b/resources/qml/CameraPositionPanel.qml
@@ -101,7 +101,7 @@ UM.Dialog
                 right: parent.right
                 margins: parent.padding
             }
-            text: "Camera zoom factor"
+            text: "Camera zoom factor (Orthographic)"
             validator: DoubleValidator {}
         }
 

--- a/resources/qml/CameraPositionPanel.qml
+++ b/resources/qml/CameraPositionPanel.qml
@@ -102,7 +102,10 @@ UM.Dialog
                 margins: parent.padding
             }
             text: "Camera zoom factor (Orthographic)"
-            validator: DoubleValidator {}
+            validator: DoubleValidator
+            {
+                bottom: -0.4999999999
+            }
         }
 
         Cura.PrimaryButton

--- a/src/CameraPosition.py
+++ b/src/CameraPosition.py
@@ -36,6 +36,6 @@ class CameraPositionExtension(QObject, Extension):
         Logger.log("d", "Creating Camera Position plugin view.")
 
         # Create the plugin dialog component
-        plugin_path = PluginRegistry.getInstance().getPluginPath("CameraPosition")
+        plugin_path = PluginRegistry.getInstance().getPluginPath("cura-camera-position")
         path = os.path.join(plugin_path, "resources", "qml", "CameraPositionPanel.qml")
         self._view = CuraApplication.getInstance().createQmlComponent(path, {"manager": self})

--- a/src/CameraPosition.py
+++ b/src/CameraPosition.py
@@ -36,6 +36,6 @@ class CameraPositionExtension(QObject, Extension):
         Logger.log("d", "Creating Camera Position plugin view.")
 
         # Create the plugin dialog component
-        plugin_path = PluginRegistry.getInstance().getPluginPath("cura-camera-position")
+        plugin_path = PluginRegistry.getInstance().getPluginPath(self.getPluginId())
         path = os.path.join(plugin_path, "resources", "qml", "CameraPositionPanel.qml")
         self._view = CuraApplication.getInstance().createQmlComponent(path, {"manager": self})


### PR DESCRIPTION
There are three fixes I'd like to merge in.
* Support for SDK 7.0 instead of 6.1. Though likely it'll become 7.1 instead.
* Plug-in name was `CameraPosition`, apparently, but that's not anywhere in the code. Since the repository is named `cura-camera-position`, I changed it to that.
* As of the latest changes to [the pull request](https://github.com/Ultimaker/Uranium/pull/503), the zoom factor only works with Orthographic projection. We've discussed solutions for this, but just marking it as "ortho only" is the length of effort I'm willing to put into it.

The PR will probably be merged into the upcoming Cura release. How this plug-in will be distributed still needs to be decided. Ultimaker really only wants it for their Marketing folk to be able to reproduce screenshots of Cura after updating the version, but if you like you could put it on the Marketplace. Though I think use cases are slim.